### PR TITLE
Add Python post-apply data-plane phase to plant cosmos_document injects

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -342,6 +342,8 @@ The chain reads: `priya` holds **Key Vault Contributor** on the vault → reads 
 
 The nine assignment `type`s are `entra_role`, `azure_rbac`, `api_permission`, `group_membership`, `group_ownership`, `app_ownership`, `au_membership` (plus `credentials` and `data_injects` as their own blocks). A chained path can also borrow entities from the baseline with `{ ref: victim, from: baseline }`. See `test_configs/declarative/declarative_hybrid.yml` for a worked hybrid example.
 
+A `data_inject` places material into a resource an attacker can read. Its `location_type` selects the resource family: `key_vault_secret` and `key_vault_certificate` (a Key Vault), `storage_blob` (a Storage account container), and `cosmos_document` (a Cosmos DB container). The `material` is `app_secret` (bound to a declared credential via `credential_ref`), `app_client_id` (the client id of an application via `source_ref`), `app_certificate` (a certificate file via `file_path`), or `literal` (arbitrary content via `literal_value`). Key Vault and Storage injects are written by Terraform; `cosmos_document` injects are planted by the data-plane phase that runs after the Terraform apply, using the Cosmos account key to upsert one document per inject. See `test_configs/declarative/declarative_cosmos_inject.yml` for a worked Cosmos example.
+
 ## Group-Based Assignment
 
 All identity- and resource-based techniques (except ApplicationOwnershipAbuse) support group-based assignment via `assignment_type: group_member` or `group_owner`. With `group_member`, the privilege is assigned to a security group and the initial-access identity is added as a **member**; with `group_owner`, the identity is added as an **owner** of the group instead.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ python-terraform
 cryptography
 python-dotenv
 litellm  # optional: only needed for `badzure generate` (LLM-authored configs); multi-provider client
+azure-cosmos  # optional: only needed to plant cosmos_document data injects (the Python post-apply data-plane phase)
 pytest  # optional: runs the offline tests in tests/ (they also self-run via `python tests/test_*.py`)

--- a/src/attack_path_manager.py
+++ b/src/attack_path_manager.py
@@ -455,8 +455,9 @@ class AttackPathManager:
     def _mi_data_injects(self, key, target_type, target_name, app_name, credential_type,
                          app_cred_key, cert_paths):
         """The data_injects that plant the looted app's credential into the MI's
-        target (parity names with legacy main.tf). Cosmos plants nothing (TF can't
-        write Cosmos items)."""
+        target (parity names with legacy main.tf). Cosmos plants the credential as
+        documents in the container via the Python post-apply data-plane phase
+        (location_type=cosmos_document is data-plane-only — not a Terraform resource)."""
         injects = []
         if target_type == 'key_vault':
             if credential_type == 'certificate':
@@ -503,7 +504,23 @@ class AttackPathManager:
                     f"{key}_sa_secret", ATTACK_PATH, material="app_secret",
                     location_type="storage_blob", location_ref=target_name,
                     name=f"{app_name}-secret.txt", credential_ref=app_cred_key))
-        # cosmos_db: no inject — TF can't write Cosmos items.
+        elif target_type == 'cosmos_db':
+            # Planted as documents in the container by the Python data-plane phase.
+            if credential_type == 'certificate':
+                injects.append(DataInject(
+                    f"{key}_cosmos_cert", ATTACK_PATH, material="app_certificate",
+                    location_type="cosmos_document", location_ref=target_name,
+                    name=f"mi-certificate-{app_name}", source_ref=app_name,
+                    file_path=cert_paths["cert"]))
+            else:
+                injects.append(DataInject(
+                    f"{key}_cosmos_secret", ATTACK_PATH, material="app_secret",
+                    location_type="cosmos_document", location_ref=target_name,
+                    name=f"mi-client-secret-{app_name}", credential_ref=app_cred_key))
+            injects.append(DataInject(
+                f"{key}_cosmos_id", ATTACK_PATH, material="app_client_id",
+                location_type="cosmos_document", location_ref=target_name,
+                name=f"mi-client-id-{app_name}", source_ref=app_name))
         return injects
 
     def macro_keyvault_secret_theft(
@@ -906,19 +923,22 @@ class AttackPathManager:
     ) -> Dict:
         """CosmosDBSecretTheft expressed as generic building blocks (Phase 4 macro).
 
-        Emits generic primitives. Unlike KV/Storage there is NO data_inject:
-        Terraform can't write items into
-        Cosmos, so the looted app's secret is minted but not planted (the operator
-        places it). The escalation is the Cosmos DATA-PLANE grant.
+        Emits generic primitives. The looted app's client secret is planted as a
+        document in the Cosmos container (location_type=cosmos_document), so the
+        attacker who reaches the data plane can query it — parity with KV/Storage.
+        The document is written by the Python post-apply data-plane phase
+        (location_type=cosmos_document is data-plane-only, not a Terraform resource).
 
         The chain, as building blocks:
           1. AppCredential(password) — mint the looted (high-priv) app's client secret.
-          2. AzureRbacAssignment(data_plane=cosmos_sql) — grant the compromised
+          2. DataInject      — plant that secret as a Cosmos document named
+                               'client-secret-<app>' (material=app_secret).
+          3. AzureRbacAssignment(data_plane=cosmos_sql) — grant the compromised
                                principal (or its group) 'Cosmos DB Built-in Data
                                Contributor' on the Cosmos account.
-          3. EntraRoleAssignment / ApiPermission — the looted app's privileges.
-          4. GroupMembership / GroupOwnership — for indirect (group-based) access.
-          5. AppCredential (no inject) — for service_principal initial access, mint the
+          4. EntraRoleAssignment / ApiPermission — the looted app's privileges.
+          5. GroupMembership / GroupOwnership — for indirect (group-based) access.
+          6. AppCredential (no inject) — for service_principal initial access, mint the
                                SP's own secret; surfaced via the generic_app_credentials
                                TF output.
 
@@ -958,13 +978,20 @@ class AttackPathManager:
         groups = {}
         entry_point = attack_config.get('entry_point', 'compromised_identity')
 
-        # 1. Mint the looted app's client secret (NOT planted — no Cosmos inject).
+        # 1. Mint the looted app's client secret + 2. plant it as a Cosmos document.
+        cred_key = f"{key}_app_secret"
         primitives.append(AppCredential(
-            f"{key}_app_secret", ATTACK_PATH, app_ref=app_name, type="password",
+            cred_key, ATTACK_PATH, app_ref=app_name, type="password",
             display_name="BadZureClientSecret",
         ))
+        primitives.append(DataInject(
+            f"{key}_cosmos_doc", ATTACK_PATH,
+            material="app_secret", location_type="cosmos_document",
+            location_ref=cosmos_db_name, name=f"client-secret-{app_name}",
+            credential_ref=cred_key,
+        ))
 
-        # 2. Cosmos DB Built-in Data Contributor (data-plane) — to the principal
+        # 3. Cosmos DB Built-in Data Contributor (data-plane) — to the principal
         #    directly, or to the group for indirect (group_member / group_owner) access.
         if assignment_type in ('group_member', 'group_owner'):
             if assignment_type == 'group_owner':
@@ -1005,7 +1032,7 @@ class AttackPathManager:
                 data_plane="cosmos_sql",
             ))
 
-        # 3. The looted app's privileges. Reuse the legacy resolver, then translate.
+        # 4. The looted app's privileges. Reuse the legacy resolver, then translate.
         legacy_roles, legacy_perms = {}, {}
         self._assign_app_privileges(attack_config, app_name, key, legacy_roles, legacy_perms)
         entra_role_ids, api_perm_ids, api_type = [], [], None
@@ -1026,7 +1053,7 @@ class AttackPathManager:
                     principal_ref=app_name, permission_id=perm_id, api_type=api_type,
                 ))
 
-        # 4. Initial-access credentials for the operator.
+        # 5. Initial-access credentials for the operator.
         if identity_type == 'user':
             credentials = {
                 "initial_access": "user",

--- a/src/cli.py
+++ b/src/cli.py
@@ -13,6 +13,7 @@ from src.terraform_manager import TerraformManager
 from src.output_formatter import OutputFormatter
 from src.terraform_builder import build_tfvars
 from src.scenario_loader import ScenarioLoader
+import src.dataplane as dataplane
 import src.utils as utils
 
 
@@ -137,10 +138,18 @@ class BuildCommand:
                 logging.error(stderr)
             return
 
+        # Read Terraform outputs once, then use them for both the SP-secret
+        # read-back and the post-apply data-plane phase.
+        outputs = self.terraform_mgr.get_outputs()
+
         # Surface SP secrets minted via the generic layer (same read-back the
         # Phase-2 macro path uses).
         user_creds = {ov.name: ov.credentials for ov in scenario.attack_paths}
-        self._apply_generic_sp_credentials(user_creds)
+        self._apply_generic_sp_credentials(user_creds, outputs)
+
+        # Post-apply data-plane phase: plant injects Terraform can't (cosmos_document
+        # today). Warn-and-continue — failures don't abort the build.
+        self._inject_dataplane(model, outputs)
 
         logging.info("Azure AD tenant setup completed with assigned permissions and configurations!")
         self.output_formatter.write_users_file(model.users, domain)
@@ -158,7 +167,7 @@ class BuildCommand:
 
         logging.info("Good bye.")
 
-    def _apply_generic_sp_credentials(self, user_creds: Dict) -> None:
+    def _apply_generic_sp_credentials(self, user_creds: Dict, outputs: Dict) -> None:
         """Read SP secrets minted via the generic layer back into user_creds.
 
         Initial-access service principals get their secret from the
@@ -169,13 +178,31 @@ class BuildCommand:
                   for ap, c in user_creds.items() if c.get('generic_credential_key')}
         if not needed:
             return
-        outputs = self.terraform_mgr.get_outputs()
         generic_creds = outputs.get('generic_app_credentials', {})
         for ap_name, cred_key in needed.items():
             entry = generic_creds.get(cred_key)
             if entry:
                 user_creds[ap_name]['client_id'] = entry.get('client_id')
                 user_creds[ap_name]['client_secret'] = entry.get('client_secret')
+
+    def _inject_dataplane(self, model, outputs: Dict) -> None:
+        """Run the post-apply data-plane phase: plant injects Terraform can't
+        deploy (cosmos_document today) by calling the data-plane APIs directly,
+        using values read from the Terraform outputs."""
+        items = dataplane.collect_dataplane_injects(model)
+        if not items:
+            return
+        logging.info(f"Planting {len(items)} data-plane inject(s) after apply")
+        result = dataplane.execute(
+            items, outputs, model, self.terraform_mgr.terraform_dir)
+        if result.failures:
+            logging.warning(
+                f"Data-plane phase: {result.planted} planted, "
+                f"{len(result.failures)} failed:")
+            for line in result.failures:
+                logging.warning(f"  - {line}")
+        else:
+            logging.info(f"Data-plane phase: {result.planted} inject(s) planted")
 
     # Building-block class name -> human label, in display order. AppCredential /
     # DataInject aren't "assignments" but they ARE deployed edges/material, so we

--- a/src/dataplane.py
+++ b/src/dataplane.py
@@ -1,0 +1,206 @@
+"""
+dataplane.py — the Python post-apply data-plane phase.
+
+Some attack-path material can't be planted by Terraform: the azurerm provider has
+no resource to write a Cosmos DB item, and the same is true for the data-plane and
+Graph operations BadZure will grow into (OneDrive/SharePoint content, SQL rows,
+license assignment, mail). Rather than shell those out of Terraform one by one,
+this module is a dedicated phase that runs AFTER `terraform apply`: it reads what
+it needs from Terraform outputs, then performs the imperative API calls directly.
+
+Today it implements exactly one location_type — `cosmos_document` — but the shape
+is built to extend: `collect_dataplane_injects` gathers every DataInject whose
+location_type is data-plane-only (see DATAPLANE_LOCATION_TYPES), and `execute`
+dispatches by location_type. A future onedrive_file / sql_row inject adds a
+collector branch + an executor function; nothing else moves.
+
+Split for testing: `collect_dataplane_injects`, `resolve_value`, and
+`build_document` are pure (no Azure, fully offline-testable). Only `execute`
+touches the SDK, and it lazy-imports `azure-cosmos` so labs without cosmos_document
+injects never need the package.
+"""
+import logging
+import os
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from src.primitives import DataInject, DeploymentModel
+from src.primitive_handlers import DATAPLANE_LOCATION_TYPES
+from src.terraform_builder import origin_prefixed_key, credential_origin_map
+
+
+# =============================================================================
+# Planning (pure) — gather data-plane injects and resolve their concrete values.
+# =============================================================================
+@dataclass
+class DataPlaneItem:
+    """One data-plane inject plus the resolved coordinates of its target. For a
+    cosmos_document inject the coordinates come from the model's cosmos_dbs entity
+    map (the same symbolic ref the inject's location_ref points at)."""
+    inject: DataInject
+    account_ref: str
+    database_name: str
+    container_name: str
+    partition_key_path: str
+
+
+def collect_dataplane_injects(model: DeploymentModel) -> List[DataPlaneItem]:
+    """Every DataInject in the model whose location_type is data-plane-only (has no
+    Terraform resource), paired with its target's coordinates. Order-preserving."""
+    items: List[DataPlaneItem] = []
+    for p in model.primitives:
+        if not isinstance(p, DataInject):
+            continue
+        if p.location_type not in DATAPLANE_LOCATION_TYPES:
+            continue
+        if p.location_type == "cosmos_document":
+            acct = model.cosmos_dbs.get(p.location_ref)
+            if acct is None:
+                # build_tfvars ref-validation should have caught this already.
+                raise KeyError(
+                    f"DataInject '{p.key}': cosmos_document location_ref "
+                    f"'{p.location_ref}' is not a declared cosmos_db."
+                )
+            items.append(DataPlaneItem(
+                inject=p,
+                account_ref=p.location_ref,
+                database_name=acct["database_name"],
+                container_name=acct["container_name"],
+                partition_key_path=acct["partition_key_path"],
+            ))
+    return items
+
+
+def resolve_value(inject: DataInject, outputs: Dict, cred_origin: Dict[str, str],
+                  terraform_dir: str = "") -> str:
+    """The concrete string to plant, by material:
+      literal          -> literal_value (verbatim)
+      app_certificate  -> the PEM/key file contents (file_path is relative to the
+                          terraform dir, where crypto.py writes the certs)
+      app_secret       -> the minted client secret, looked up in the
+                          generic_app_credentials TF output by the SAME
+                          origin-prefixed key the builder writes
+      app_client_id    -> the application's client id, from application_client_ids
+    """
+    material = inject.material
+    if material == "literal":
+        return inject.literal_value or ""
+    if material == "app_certificate":
+        path = inject.file_path or ""
+        if terraform_dir and not os.path.isabs(path):
+            path = os.path.join(terraform_dir, path)
+        with open(path, "r") as f:
+            return f.read()
+    if material == "app_secret":
+        bare = inject.credential_ref or ""
+        origin = cred_origin.get(bare)
+        if origin is None:
+            raise KeyError(
+                f"DataInject '{inject.key}': credential_ref '{bare}' names no "
+                f"declared app_credential."
+            )
+        key = origin_prefixed_key(bare, origin)
+        creds = outputs.get("generic_app_credentials") or {}
+        entry = creds.get(key)
+        if not entry:
+            raise KeyError(
+                f"DataInject '{inject.key}': no generic_app_credentials output for "
+                f"'{key}' (was the app credential created?)."
+            )
+        return entry.get("client_secret", "")
+    if material == "app_client_id":
+        ids = outputs.get("application_client_ids") or {}
+        client_id = ids.get(inject.source_ref or "")
+        if client_id is None:
+            raise KeyError(
+                f"DataInject '{inject.key}': no application_client_ids output for "
+                f"source_ref '{inject.source_ref}'."
+            )
+        return client_id
+    raise ValueError(f"DataInject '{inject.key}': unknown material '{material}'.")
+
+
+def build_document(item: DataPlaneItem, value: str) -> Dict:
+    """The Cosmos document to upsert: {id, <partition-key field>, content}. The
+    partition-key field is whatever partition_key_path names (BadZure defaults to
+    /id), so any single-path partition key works."""
+    pk_field = (item.partition_key_path or "/id").lstrip("/") or "id"
+    doc_id = item.inject.name
+    return {"id": doc_id, pk_field: doc_id, "content": value}
+
+
+# =============================================================================
+# Execution (touches Azure) — upsert each planned document via azure-cosmos.
+# =============================================================================
+@dataclass
+class DataPlaneResult:
+    """Per-run summary the build flow reports. Failures never abort the build or
+    taint Terraform state — they're logged per inject and counted here."""
+    planted: int = 0
+    failures: List[str] = None  # human-readable "<key>: <reason>" lines
+
+    def __post_init__(self):
+        if self.failures is None:
+            self.failures = []
+
+
+def execute(items: List[DataPlaneItem], outputs: Dict, model: DeploymentModel,
+            terraform_dir: str = "") -> DataPlaneResult:
+    """Plant every collected data-plane inject. Warn-and-continue: a single failure
+    is logged and recorded, the rest still run, and the build proceeds. Returns a
+    DataPlaneResult summary."""
+    result = DataPlaneResult()
+    if not items:
+        return result
+
+    try:
+        from azure.cosmos import CosmosClient  # lazy: only needed for cosmos injects
+    except ImportError:
+        msg = ("the 'azure-cosmos' package is required to plant cosmos_document "
+               "injects. Install it into the BadZure venv: pip install azure-cosmos")
+        logging.error(f"Data-plane phase skipped: {msg}")
+        result.failures = [f"{it.inject.key}: {msg}" for it in items]
+        return result
+
+    # The Azure SDK's HTTP logging policy emits every request/response (URLs,
+    # headers, status) and propagates to the root logger — far too noisy for the
+    # build output. Quiet the whole 'azure' logger tree to WARNING.
+    logging.getLogger("azure").setLevel(logging.WARNING)
+
+    cred_origin = credential_origin_map(model)
+    connections = outputs.get("cosmos_db_connections") or {}
+    # Cache one container client per (account, db, container) so we connect once.
+    container_clients: Dict[tuple, object] = {}
+
+    for item in items:
+        inject = item.inject
+        try:
+            conn = connections.get(item.account_ref)
+            if not conn:
+                raise KeyError(
+                    f"no cosmos_db_connections output for account "
+                    f"'{item.account_ref}'."
+                )
+            cache_key = (item.account_ref, item.database_name, item.container_name)
+            container = container_clients.get(cache_key)
+            if container is None:
+                client = CosmosClient(conn["endpoint"], credential=conn["primary_key"])
+                container = (client
+                             .get_database_client(item.database_name)
+                             .get_container_client(item.container_name))
+                container_clients[cache_key] = container
+
+            value = resolve_value(inject, outputs, cred_origin, terraform_dir)
+            container.upsert_item(build_document(item, value))
+            result.planted += 1
+            logging.info(
+                f"  planted Cosmos document '{inject.name}' in "
+                f"{item.database_name}/{item.container_name}")
+        except Exception as e:  # noqa: BLE001 — warn-and-continue per inject
+            reason = str(e)
+            result.failures.append(f"{inject.key}: {reason}")
+            logging.warning(
+                f"  failed to plant Cosmos document '{inject.name}' "
+                f"({inject.key}): {reason}")
+
+    return result

--- a/src/primitive_handlers.py
+++ b/src/primitive_handlers.py
@@ -72,7 +72,15 @@ INJECT_LOCATION_TO_MAP = {
     "key_vault_secret": "key_vaults",
     "key_vault_certificate": "key_vaults",
     "storage_blob": "storage_accounts",
+    # Data-plane-only (no Terraform resource): planted by the Python post-apply
+    # data-plane phase (src/dataplane.py), not generic.tf. Listed here so
+    # location_ref still ref-validates against the cosmos_dbs entity map.
+    "cosmos_document": "cosmos_dbs",
 }
+
+# location_types that have NO Terraform resource — the builder keeps them out of
+# the data_injects tfvars families, and src/dataplane.py plants them after apply.
+DATAPLANE_LOCATION_TYPES = frozenset({"cosmos_document"})
 
 
 @dataclass(frozen=True)

--- a/src/primitives.py
+++ b/src/primitives.py
@@ -94,13 +94,15 @@ class AppCredential(Primitive):
 
 @dataclass
 class DataInject(Primitive):
-    """-> azurerm_key_vault_secret / _certificate / storage_blob. Plant material
-    an attacker can loot. The app_secret join references an AppCredential by
+    """-> azurerm_key_vault_secret / _certificate / storage_blob, OR (for
+    location_type=cosmos_document) a document planted by the Python post-apply
+    data-plane phase (src/dataplane.py) rather than Terraform. Plant material an
+    attacker can loot. The app_secret join references an AppCredential by
     credential_ref (BARE key here; the builder origin-prefixes it to match
-    g_inject_value indexing in generic.tf)."""
+    g_inject_value indexing in generic.tf / the data-plane resolver)."""
     material: str                              # app_secret | app_certificate | app_client_id | literal
-    location_type: str                         # key_vault_secret | key_vault_certificate | storage_blob
-    location_ref: str                          # key_vault ref or storage_account ref
+    location_type: str                         # key_vault_secret | key_vault_certificate | storage_blob | cosmos_document
+    location_ref: str                          # key_vault / storage_account / cosmos_db ref
     name: str                                  # secret / certificate / blob name
     source_ref: Optional[str] = None           # app_ref for app_client_id / app_certificate
     credential_ref: Optional[str] = None       # AppCredential key for material=app_secret (bare)

--- a/src/terraform_builder.py
+++ b/src/terraform_builder.py
@@ -37,7 +37,7 @@ from src.primitives import (
     DeploymentModel, Primitive, EntraRoleAssignment, AppCredential, DataInject,
     RANDOM, ATTACK_PATH, value_fields,
 )
-from src.primitive_handlers import handler_for, CREDENTIAL
+from src.primitive_handlers import handler_for, CREDENTIAL, DATAPLANE_LOCATION_TYPES
 
 
 class LabValidationError(ValueError):
@@ -46,6 +46,24 @@ class LabValidationError(ValueError):
 
 _ORIGIN_FAMILY_PREFIX = {RANDOM: "random", ATTACK_PATH: "attack_path"}
 _ORIGIN_KEY_PREFIX = {RANDOM: "random:", ATTACK_PATH: "ap:"}
+
+
+def origin_prefixed_key(bare_key: str, origin: str) -> str:
+    """Origin-prefix a credential key the way generic.tf keys credentials (and the
+    TF generic_app_credentials output): 'foo' + attack_path -> 'ap:foo'. Shared so
+    the Python data-plane phase (src/dataplane.py) resolves an app_secret inject
+    against the SAME key the builder writes."""
+    return _ORIGIN_KEY_PREFIX[origin] + bare_key
+
+
+def credential_origin_map(model: DeploymentModel) -> Dict[str, str]:
+    """Map of bare AppCredential key -> origin, for credential_ref prefixing.
+    Shared between the builder and the data-plane resolver."""
+    out: Dict[str, str] = {}
+    for p in model.primitives:
+        if isinstance(p, AppCredential):
+            out[p.key] = p.origin
+    return out
 
 # Required companion field for each data_inject material.
 _MATERIAL_REQUIRES = {
@@ -88,7 +106,22 @@ class TerraformBuilder:
         for attr in DeploymentModel.ENTITY_MAPS:
             tfvars[attr] = groups if attr == "groups" else getattr(self.model, attr)
         tfvars.update(families)
+        # Only the Cosmos accounts a cosmos_document inject targets need their
+        # master key surfaced to the data-plane phase; the cosmos_db_connections
+        # output iterates exactly this allowlist (baseline accounts are excluded).
+        tfvars["cosmos_dataplane_refs"] = self._cosmos_dataplane_refs()
         return tfvars
+
+    def _cosmos_dataplane_refs(self) -> List[str]:
+        """Sorted cosmos_db refs targeted by a cosmos_document inject — the only
+        accounts whose endpoint+master key the data-plane phase reads back. Baseline
+        Cosmos accounts with no inject are left out of the connections output."""
+        refs = {
+            p.location_ref
+            for p in self.model.primitives
+            if isinstance(p, DataInject) and p.location_type == "cosmos_document"
+        }
+        return sorted(refs)
 
     # -- step 1: is_attack_path_group derivation ------------------------------
     def _role_assignable_groups(self) -> set:
@@ -161,13 +194,19 @@ class TerraformBuilder:
     def _build_families(self) -> Dict[str, Dict]:
         families: Dict[str, Dict] = {}
         for p in self.model.primitives:
+            # Data-plane-only injects (e.g. cosmos_document) have no Terraform
+            # resource — they're planted by src/dataplane.py after apply, so keep
+            # them out of the tfvars families. They are still ref-validated above.
+            if isinstance(p, DataInject) and p.location_type in DATAPLANE_LOCATION_TYPES:
+                continue
+
             base = handler_for(p).base_family
             family = f"{_ORIGIN_FAMILY_PREFIX[p.origin]}_{base}"
             value = {f: getattr(p, f) for f in value_fields(type(p))}
 
             if isinstance(p, DataInject) and p.material == "app_secret" and p.credential_ref:
                 cred_origin = self._credential_origin[p.credential_ref]
-                value["credential_ref"] = _ORIGIN_KEY_PREFIX[cred_origin] + p.credential_ref
+                value["credential_ref"] = origin_prefixed_key(p.credential_ref, cred_origin)
 
             bucket = families.setdefault(family, {})
             if p.key in bucket:

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -37,3 +37,29 @@ output "generic_app_credentials" {
   }
   sensitive = true
 }
+
+# Cosmos account connection info (endpoint + master key) so the Python post-apply
+# data-plane phase can upsert cosmos_document data injects. Sensitive: the master
+# key grants full data-plane access. Scoped to cosmos_dataplane_refs — only the
+# accounts an inject targets — so baseline Cosmos accounts' keys are NOT surfaced
+# here. (Note: tfstate still holds every account's primary_key as a resource
+# attribute; this scopes the OUTPUT channel, not state.)
+output "cosmos_db_connections" {
+  description = "Endpoint + primary key for inject-targeted Cosmos accounts only"
+  value = {
+    for k in var.cosmos_dataplane_refs : k => {
+      endpoint    = azurerm_cosmosdb_account.cosmos_dbs[k].endpoint
+      primary_key = azurerm_cosmosdb_account.cosmos_dbs[k].primary_key
+    }
+  }
+  sensitive = true
+}
+
+# app ref -> client_id, so the data-plane phase can resolve app_client_id-material
+# injects (the client id is non-sensitive public metadata).
+output "application_client_ids" {
+  description = "Symbolic app ref -> application (client) id"
+  value = {
+    for k, v in azuread_application_registration.spns : k => v.client_id
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -140,3 +140,13 @@ variable "cosmos_dbs" {
   }))
   default = {}
 }
+
+# Cosmos accounts targeted by a cosmos_document data inject — the ONLY accounts
+# whose master key the cosmos_db_connections output surfaces to the Python
+# data-plane phase. Baseline Cosmos accounts with no inject are omitted, so their
+# keys are never read back through `terraform output`.
+variable "cosmos_dataplane_refs" {
+  description = "Subset of cosmos_dbs keys whose connection info the data-plane phase needs"
+  type        = list(string)
+  default     = []
+}

--- a/test_configs/declarative/declarative_cosmos_inject.yml
+++ b/test_configs/declarative/declarative_cosmos_inject.yml
@@ -1,0 +1,70 @@
+# Declarative graph config — a CosmosDBSecretTheft-equivalent chain written
+# explicitly (Tier 2) instead of via the `privilege_escalation:` macro. Shows the
+# cosmos_document data_inject planting both a looted app secret and an arbitrary
+# literal document in the same container.
+#
+# In this build path the cosmos_document injects are planted by the Python
+# post-apply data-plane phase (src/dataplane.py), not Terraform — Terraform only
+# creates the Cosmos account/database/container.
+#
+# Live test:
+#   python badzure.py build --config test_configs/declarative/declarative_cosmos_inject.yml --verbose
+#   python badzure.py destroy --verbose
+#
+# tenant_id/domain/subscription_id resolve from BADZURE_* env vars when null.
+
+tenant:
+  tenant_id: null
+  domain: null
+  subscription_id: null
+
+attack_paths:
+  cosmos_inject:
+    objective:
+      # Machine-checkable objective for the reachability gate: a controlled
+      # principal can read the Cosmos container that holds the looted secret.
+      name: "Global Administrator via Cosmos DB"
+      capability: read_cosmos
+      target_ref: cosmos-replace-me
+      impact: critical
+      description: "Read a high-privilege app's client secret planted as a Cosmos document."
+    metadata:
+      complexity: low
+      tags: [cosmos-db]
+      mitre: [T1078, T1552]
+    initial_access:
+      method: compromised_identity
+      principal_ref: alice
+
+    identities:
+      users:        [{ ref: alice }]
+      applications: [{ ref: app_highpriv }]
+    resources:
+      # On this declarative path the ref doubles as the real Cosmos account name,
+      # which must be GLOBALLY UNIQUE (3-44 chars, lowercase alphanumerics +
+      # hyphens). Change cosmos-replace-me to your own unique value below.
+      cosmos_dbs:   [{ ref: cosmos-replace-me }]
+
+    assignments:
+      # alice holds Cosmos DB Built-in Data Contributor (data plane) on the account.
+      - { id: a1, type: azure_rbac, principal_ref: alice,
+          role: "00000000-0000-0000-0000-000000000002", scope_ref: cosmos-replace-me,
+          scope_resource_type: cosmos_db, data_plane: cosmos_sql }
+      # the looted app is Global Administrator — reading its secret is the escalation.
+      - { id: a2, type: entra_role, principal_ref: app_highpriv,
+          role: "Global Administrator" }
+
+    credentials:
+      - { ref: app_secret, app_ref: app_highpriv, type: password }
+
+    data_injects:
+      # the looted app's client secret, planted as a queryable Cosmos document by
+      # the Python data-plane phase
+      - { id: d1, material: app_secret, credential_ref: app_secret,
+          location_type: cosmos_document, location_ref: cosmos-replace-me,
+          name: client-secret-app-highpriv }
+      # an arbitrary literal document (no app secret required) — shows the same
+      # mechanism seeds Cosmos with non-credential content
+      - { id: d2, material: literal, literal_value: '{"note":"badzure seed"}',
+          location_type: cosmos_document, location_ref: cosmos-replace-me,
+          name: seed-doc }

--- a/tests/test_dataplane.py
+++ b/tests/test_dataplane.py
@@ -1,0 +1,162 @@
+"""
+test_dataplane.py — offline test of the Python post-apply data-plane phase.
+
+Exercises the PURE parts of src/dataplane.py (no Azure): collecting cosmos_document
+injects from a model, resolving each material's concrete value from Terraform
+outputs / local files / literals, and shaping the Cosmos document. The azure-cosmos
+upsert in execute() is the live acceptance step, not covered here.
+
+Runs two ways:
+    python tests/test_dataplane.py
+    pytest tests/test_dataplane.py
+"""
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.primitives import (  # noqa: E402
+    DeploymentModel, DataInject, AppCredential, ATTACK_PATH,
+)
+import src.dataplane as dataplane  # noqa: E402
+
+
+def _cosmos(pk="/id"):
+    return {"cos01": {"name": "cos01", "location": "West US",
+                      "resource_group_name": "rg1", "database_name": "cos01-db",
+                      "container_name": "cos01-container", "partition_key_path": pk}}
+
+
+def _model(primitives, pk="/id"):
+    return DeploymentModel(
+        domain="contoso.com", applications={"app_hp": {"display_name": "app_hp"}},
+        cosmos_dbs=_cosmos(pk), primitives=primitives)
+
+
+# --- collect_dataplane_injects ----------------------------------------------
+def test_collect_only_dataplane_injects():
+    primitives = [
+        DataInject("kv", ATTACK_PATH, material="app_secret",
+                   location_type="key_vault_secret", location_ref="kv01",
+                   name="s", credential_ref="c"),
+        DataInject("cos", ATTACK_PATH, material="literal",
+                   location_type="cosmos_document", location_ref="cos01",
+                   name="seed", literal_value="{}"),
+    ]
+    items = dataplane.collect_dataplane_injects(_model(primitives))
+    # the KV inject (a Terraform resource) is ignored; only cosmos_document is taken
+    assert len(items) == 1 and items[0].inject.key == "cos"
+    assert items[0].database_name == "cos01-db"
+    assert items[0].container_name == "cos01-container"
+    assert items[0].partition_key_path == "/id"
+
+
+def test_collect_unknown_account_raises():
+    primitives = [DataInject("cos", ATTACK_PATH, material="literal",
+                             location_type="cosmos_document", location_ref="nope",
+                             name="seed", literal_value="{}")]
+    try:
+        dataplane.collect_dataplane_injects(_model(primitives))
+        assert False, "expected KeyError for unknown cosmos ref"
+    except KeyError:
+        pass
+
+
+# --- resolve_value (one per material) ---------------------------------------
+def test_resolve_literal():
+    inj = DataInject("d", ATTACK_PATH, material="literal",
+                     location_type="cosmos_document", location_ref="cos01",
+                     name="seed", literal_value='{"note":"hi"}')
+    assert dataplane.resolve_value(inj, {}, {}) == '{"note":"hi"}'
+
+
+def test_resolve_app_client_id():
+    inj = DataInject("d", ATTACK_PATH, material="app_client_id",
+                     location_type="cosmos_document", location_ref="cos01",
+                     name="id", source_ref="app_hp")
+    outputs = {"application_client_ids": {"app_hp": "1111-2222"}}
+    assert dataplane.resolve_value(inj, outputs, {}) == "1111-2222"
+
+
+def test_resolve_app_secret_uses_origin_prefixed_key():
+    cred = AppCredential("app_hp_secret", ATTACK_PATH, app_ref="app_hp", type="password")
+    inj = DataInject("d", ATTACK_PATH, material="app_secret",
+                     location_type="cosmos_document", location_ref="cos01",
+                     name="sec", credential_ref="app_hp_secret")
+    model = _model([cred, inj])
+    cred_origin = dataplane.credential_origin_map(model)
+    # output is keyed by the origin-prefixed credential key, like generic.tf
+    outputs = {"generic_app_credentials": {"ap:app_hp_secret": {"client_secret": "S3cr3t"}}}
+    assert dataplane.resolve_value(inj, outputs, cred_origin) == "S3cr3t"
+
+
+def test_resolve_app_certificate_reads_file_relative_to_tf_dir():
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, "cert.pem"), "w") as f:
+            f.write("-----BEGIN CERT-----\nXYZ\n-----END CERT-----\n")
+        inj = DataInject("d", ATTACK_PATH, material="app_certificate",
+                         location_type="cosmos_document", location_ref="cos01",
+                         name="cert", source_ref="app_hp", file_path="cert.pem")
+        out = dataplane.resolve_value(inj, {}, {}, terraform_dir=d)
+        assert out.startswith("-----BEGIN CERT-----")
+
+
+def test_resolve_missing_secret_output_raises():
+    cred = AppCredential("c", ATTACK_PATH, app_ref="app_hp", type="password")
+    inj = DataInject("d", ATTACK_PATH, material="app_secret",
+                     location_type="cosmos_document", location_ref="cos01",
+                     name="sec", credential_ref="c")
+    cred_origin = dataplane.credential_origin_map(_model([cred, inj]))
+    try:
+        dataplane.resolve_value(inj, {"generic_app_credentials": {}}, cred_origin)
+        assert False, "expected KeyError for missing credential output"
+    except KeyError:
+        pass
+
+
+# --- build_document ----------------------------------------------------------
+def test_build_document_default_partition_key():
+    inj = DataInject("d", ATTACK_PATH, material="literal",
+                     location_type="cosmos_document", location_ref="cos01",
+                     name="doc1", literal_value="v")
+    item = dataplane.collect_dataplane_injects(_model([inj]))[0]
+    # /id partition key: the pk field IS id, so just {id, content}
+    assert dataplane.build_document(item, "the-value") == {"id": "doc1", "content": "the-value"}
+
+
+def test_build_document_custom_partition_key():
+    inj = DataInject("d", ATTACK_PATH, material="literal",
+                     location_type="cosmos_document", location_ref="cos01",
+                     name="doc1", literal_value="v")
+    item = dataplane.collect_dataplane_injects(_model([inj], pk="/pk"))[0]
+    # non-/id partition key becomes its own field, populated with the doc id
+    assert dataplane.build_document(item, "the-value") == \
+        {"id": "doc1", "pk": "doc1", "content": "the-value"}
+
+
+# --- execute -----------------------------------------------------------------
+def test_execute_empty_is_noop():
+    res = dataplane.execute([], {}, _model([]))
+    assert res.planted == 0 and res.failures == []
+
+
+def _main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL  {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/tests/test_macro_cosmosdb_secret_theft.py
+++ b/tests/test_macro_cosmosdb_secret_theft.py
@@ -3,9 +3,10 @@ test_macro_cosmosdb_secret_theft.py — offline test of the Phase-4 macro.
 
 Drives the real `macro_cosmosdb_secret_theft` (no Azure) through the Terraform
 builder and asserts the emitted generic families model the Cosmos-secret-theft
-chain correctly across its variants. Unlike KV/Storage there is NO data_inject
-(Terraform can't write Cosmos items) — the escalation is the Cosmos DATA-PLANE
-RBAC grant (data_plane=cosmos_sql) plus the minted app secret.
+chain correctly across its variants. The looted secret is planted as a
+cosmos_document DataInject, but that is a data-plane-only inject: the builder
+keeps it OUT of the Terraform data_injects family (the Python post-apply
+data-plane phase plants it), so it lives on the model's primitives instead.
 
 Runs two ways:
     python tests/test_macro_cosmosdb_secret_theft.py
@@ -60,12 +61,24 @@ def test_user_direct_azureadrole():
     result = _run_macro(cfg)
     out = build_tfvars(_model(result["primitives"], result["groups"]))
 
-    # one password app_credential on the looted app; NO data_inject (TF can't plant in Cosmos)
+    # one password app_credential on the looted app
     creds = out["attack_path_app_credentials"]
     assert len(creds) == 1
-    cred = next(iter(creds.values()))
+    cred_key, cred = next(iter(creds.items()))
     assert cred["app_ref"] == "app-highpriv" and cred["type"] == "password"
+
+    # the secret is planted as a cosmos_document inject — but as a data-plane-only
+    # inject it is NOT emitted into the Terraform data_injects family; it lives on
+    # the model's primitives for the Python data-plane phase to plant after apply.
     assert not out.get("attack_path_data_injects")
+    injects = [p for p in result["primitives"]
+               if getattr(p, "location_type", None) == "cosmos_document"]
+    assert len(injects) == 1
+    inj = injects[0]
+    assert inj.material == "app_secret"
+    assert inj.location_ref == "cosmosfixture"
+    assert inj.name == "client-secret-app-highpriv"
+    assert inj.credential_ref == cred_key
 
     # Cosmos data-plane grant to the user directly
     rbac = next(iter(out["attack_path_azure_rbac_assignments"].values()))

--- a/tests/test_macro_managed_identity_abuse.py
+++ b/tests/test_macro_managed_identity_abuse.py
@@ -4,8 +4,9 @@ test_macro_managed_identity_abuse.py — offline test of the Phase-4 MI macro.
 Drives the real `macro_managed_identity_abuse` (no Azure) through the Terraform
 builder and asserts the emitted generic families model the chain: source-Contributor
 -> the source's managed identity -> grants on the target -> the looted app's
-credential planted there. Covers KV (secret + certificate), storage, cosmos (no
-inject), group assignment, and SP initial access.
+credential planted there. Covers KV (secret + certificate), storage, cosmos
+(data-plane-only document injects, kept out of the TF data_injects family), group
+assignment, and SP initial access.
 
 The cert generator is monkeypatched (no file I/O).
 
@@ -115,15 +116,38 @@ def test_vm_to_storage_secret():
     assert all(i["location_type"] == "storage_blob" for i in injects.values())
 
 
-def test_vm_to_cosmos_has_no_inject():
+def _cosmos_document_injects(result):
+    return [p for p in result["primitives"]
+            if getattr(p, "location_type", None) == "cosmos_document"]
+
+
+def test_vm_to_cosmos_plants_secret_documents():
     cfg = {"privilege_escalation": "ManagedIdentityAbuse", "source_type": "vm",
            "target_resource_type": "cosmos_db", "initial_access": "user",
            "credential_type": "secret", "method": "AzureADRole", "entra_role": GA_ROLE}
     result, out = _run(cfg)
     mi = [r for r in _rbac(out) if r["principal_type"] == "managed_identity"]
     assert len(mi) == 1 and mi[0]["role"] == COSMOS_ROLE and mi[0]["data_plane"] == "cosmos_sql"
-    assert not out.get("attack_path_data_injects")             # TF can't write Cosmos items
+    # cosmos_document injects are data-plane-only — kept OUT of the TF family; the
+    # Python data-plane phase plants secret + client id as documents after apply.
+    assert not out.get("attack_path_data_injects")
+    injects = _cosmos_document_injects(result)
+    assert {p.material for p in injects} == {"app_secret", "app_client_id"}
+    assert {p.name for p in injects} == {"mi-client-secret-app-hp", "mi-client-id-app-hp"}
     assert next(iter(out["attack_path_app_credentials"].values()))["type"] == "password"
+
+
+def test_vm_to_cosmos_cert_plants_certificate_document():
+    cfg = {"privilege_escalation": "ManagedIdentityAbuse", "source_type": "vm",
+           "target_resource_type": "cosmos_db", "initial_access": "user",
+           "credential_type": "certificate", "method": "AzureADRole", "entra_role": GA_ROLE}
+    result, out = _run(cfg)
+    assert not out.get("attack_path_data_injects")
+    injects = _cosmos_document_injects(result)
+    assert {p.material for p in injects} == {"app_certificate", "app_client_id"}
+    cert = next(p for p in injects if p.material == "app_certificate")
+    assert cert.file_path and cert.name == "mi-certificate-app-hp"   # the PEM the phase uploads
+    assert next(iter(out["attack_path_app_credentials"].values()))["type"] == "certificate"
 
 
 def test_group_member_routes_source_contributor_to_group():

--- a/tests/test_scenario_loader.py
+++ b/tests/test_scenario_loader.py
@@ -24,6 +24,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from src.entity_generator import EntityGenerator  # noqa: E402
 from src.scenario_loader import ScenarioLoader, ScenarioConfigError  # noqa: E402
 from src.terraform_builder import build_tfvars  # noqa: E402
+import src.dataplane as dataplane  # noqa: E402
 
 GA_ROLE = "62e90394-69f5-4237-9190-012177145e10"  # Global Administrator
 _REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -118,6 +119,83 @@ def test_kv_theft_chain_compiles_to_generic_families():
     assert cred["initial_access"] == "user"
     assert cred["user_principal_name"] == "alice@contoso.com"
     assert cred["password"] == model.users["alice"]["password"]
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 explicit graph — cosmos_document injects (app_secret + arbitrary literal).
+# In approach 2 these are DATA-PLANE-ONLY: they compile into the model's primitives
+# and the Python data-plane phase plants them, but the builder keeps them OUT of the
+# Terraform data_injects family. Exercises the loader -> planner -> resolver path.
+# ---------------------------------------------------------------------------
+_COSMOS_THEFT = {
+    "schema": "graph",
+    "attack_paths": {
+        "cosmos_theft": {
+            "objective": {"capability": "read_cosmos", "target_ref": "cos01"},
+            "initial_access": {"method": "compromised_identity", "principal_ref": "alice"},
+            "identities": {
+                "users": [{"ref": "alice"}],
+                "applications": [{"ref": "app_highpriv"}],
+            },
+            "resources": {"cosmos_dbs": [{"ref": "cos01"}]},
+            "assignments": [
+                {"id": "a1", "type": "azure_rbac", "principal_ref": "alice",
+                 "role": "00000000-0000-0000-0000-000000000002", "scope_ref": "cos01",
+                 "scope_resource_type": "cosmos_db", "data_plane": "cosmos_sql"},
+                {"id": "a2", "type": "entra_role", "principal_ref": "app_highpriv",
+                 "role": GA_ROLE},
+            ],
+            "credentials": [
+                {"ref": "app_secret", "app_ref": "app_highpriv", "type": "password"},
+            ],
+            "data_injects": [
+                {"id": "d1", "material": "app_secret", "credential_ref": "app_secret",
+                 "location_type": "cosmos_document", "location_ref": "cos01",
+                 "name": "client-secret-app_highpriv"},
+                {"id": "d2", "material": "literal", "literal_value": '{"k":"v"}',
+                 "location_type": "cosmos_document", "location_ref": "cos01",
+                 "name": "seed-doc"},
+            ],
+        }
+    },
+}
+
+
+def test_explicit_cosmos_document_injects_compile_offline():
+    scenario = _load(_COSMOS_THEFT)
+    model = scenario.model
+    out = build_tfvars(model)  # also runs ref-validation
+
+    # cosmos_document injects are data-plane-only: NOT in the TF data_injects family.
+    assert not out.get("attack_path_data_injects")
+
+    # but they DO compile into the model's primitives, and the planner picks them up
+    # with coordinates resolved from the synthesized cosmos entity.
+    items = dataplane.collect_dataplane_injects(model)
+    by_name = {it.inject.name: it for it in items}
+    assert set(by_name) == {"client-secret-app_highpriv", "seed-doc"}
+    secret_item = by_name["client-secret-app_highpriv"]
+    assert secret_item.account_ref == "cos01"
+    assert secret_item.database_name and secret_item.container_name
+    assert secret_item.partition_key_path == "/id"
+
+    # the cosmos data-plane RBAC grant still resolves against the cosmos_dbs map
+    rbac = out["attack_path_azure_rbac_assignments"]["cosmos_theft__a1"]
+    assert rbac["scope_resource_type"] == "cosmos_db" and rbac["scope_ref"] == "cos01"
+    assert rbac["data_plane"] == "cosmos_sql"
+
+    # value resolution: literal verbatim; app_secret via the SAME origin-prefixed
+    # credential key the builder/TF output use.
+    cred_origin = dataplane.credential_origin_map(model)
+    literal_item = by_name["seed-doc"]
+    assert dataplane.resolve_value(literal_item.inject, {}, cred_origin) == '{"k":"v"}'
+    fake_outputs = {"generic_app_credentials":
+                    {"ap:cosmos_theft__app_secret": {"client_secret": "S3cr3t!"}}}
+    assert dataplane.resolve_value(secret_item.inject, fake_outputs, cred_origin) == "S3cr3t!"
+
+    # build_document shape: {id, <pk field 'id'>, content}
+    assert dataplane.build_document(literal_item, '{"k":"v"}') == \
+        {"id": "seed-doc", "content": '{"k":"v"}'}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_terraform_builder_golden.py
+++ b/tests/test_terraform_builder_golden.py
@@ -275,6 +275,66 @@ def test_credential_ref_is_origin_prefixed():
     assert injected["credential_ref"] == "ap:automation_secret"
 
 
+def test_cosmos_document_inject_is_filtered_from_tf_families():
+    """cosmos_document is a data-plane-only inject: the builder still ref-validates
+    it but must NOT emit it into any data_injects family (the Python data-plane
+    phase plants it after apply). A regular storage_blob inject still emits."""
+    model = DeploymentModel(
+        domain="contoso.com",
+        storage_accounts={"sa01": {"name": "sa01", "resource_group_name": "rg1"}},
+        cosmos_dbs={"cos01": {"name": "cos01", "resource_group_name": "rg1",
+                              "database_name": "db", "container_name": "c",
+                              "partition_key_path": "/id"}},
+        primitives=[
+            DataInject("cosdoc", ATTACK_PATH, material="literal",
+                       location_type="cosmos_document", location_ref="cos01",
+                       name="seed", literal_value="{}"),
+            DataInject("blob", ATTACK_PATH, material="literal",
+                       location_type="storage_blob", location_ref="sa01",
+                       name="loot.txt", literal_value="x"),
+        ],
+    )
+    out = build_tfvars(model)  # validate() still runs over the cosmos inject
+    injects = out.get("attack_path_data_injects", {})
+    assert "cosdoc" not in injects        # cosmos_document filtered out
+    assert "blob" in injects              # storage_blob still emitted
+
+
+def test_cosmos_dataplane_refs_scopes_to_targeted_accounts_only():
+    """cosmos_dataplane_refs (which accounts' master key the output surfaces) must
+    list ONLY the Cosmos accounts an inject targets — baseline accounts are out."""
+    model = DeploymentModel(
+        domain="contoso.com",
+        cosmos_dbs={
+            "looted": {"name": "looted", "resource_group_name": "rg1",
+                       "database_name": "db", "container_name": "c",
+                       "partition_key_path": "/id"},
+            "baseline_noise": {"name": "baseline-noise", "resource_group_name": "rg1",
+                               "database_name": "db", "container_name": "c",
+                               "partition_key_path": "/id"},
+        },
+        primitives=[
+            DataInject("cosdoc", ATTACK_PATH, material="literal",
+                       location_type="cosmos_document", location_ref="looted",
+                       name="seed", literal_value="{}"),
+        ],
+    )
+    out = build_tfvars(model)
+    assert out["cosmos_dataplane_refs"] == ["looted"]   # baseline_noise excluded
+
+
+def test_cosmos_dataplane_refs_empty_without_injects():
+    """No cosmos_document inject -> empty allowlist -> the output surfaces nothing."""
+    model = DeploymentModel(
+        domain="contoso.com",
+        cosmos_dbs={"baseline_noise": {"name": "bn", "resource_group_name": "rg1",
+                                       "database_name": "db", "container_name": "c",
+                                       "partition_key_path": "/id"}},
+        primitives=[],
+    )
+    assert build_tfvars(model)["cosmos_dataplane_refs"] == []
+
+
 # ---------------------------------------------------------------------------
 # Self-runner (no pytest required)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Terraform/azurerm has no resource to write a Cosmos DB item, so cosmos_document data injects were previously minted but not planted. This adds a dedicated Python phase that runs after `terraform apply`: it reads connection info from Terraform outputs and upserts one document per inject via azure-cosmos. Terraform stays the control-plane substrate (it creates the account/database/container); the document write is the only thing that leaves the Terraform graph.

How it works:
- src/dataplane.py: pure planner/resolver (collect_dataplane_injects, resolve_value, build_document) + a lazy azure-cosmos executor (upsert per inject, master-key auth, warn-and-continue so one failure never taints the build). Azure SDK HTTP logging is quieted to WARNING.
- terraform_builder filters data-plane-only injects out of the tfvars families (they have no TF resource) while still ref-validating them; shared origin_prefixed_key / credential_origin_map helpers keep secret-key resolution consistent with generic.tf.
- cli wires the phase in after apply, reading terraform outputs once.

Terraform footprint (only):
- outputs.tf: application_client_ids, and cosmos_db_connections (sensitive) scoped to cosmos_dataplane_refs so only inject-targeted accounts surface a master key — a baseline of decoy Cosmos accounts exposes none.
- variables.tf: cosmos_dataplane_refs allowlist.

Macros (macro_cosmosdb_secret_theft, _mi_data_injects cosmos branch) now emit cosmos_document injects; teardown is automatic (documents die with the account).

Tests: new tests/test_dataplane.py (planner/resolver/build_document); macro, loader, and golden tests assert the inject lands on the model's primitives and is kept out of the TF families, plus the cosmos_dataplane_refs scoping. 146 offline tests pass. Adds optional azure-cosmos dependency; live fixture declarative_cosmos_inject.yml.